### PR TITLE
ERRORCODE and ERRORTEXT

### DIFF
--- a/extensions/ltb_json.cpp
+++ b/extensions/ltb_json.cpp
@@ -18,11 +18,16 @@ struct ldpl_list {
     vector<T> inner_collection;
 };
 #endif
+#define ldpl_number double
 
 string LTB_JSON_IN_JSON;
 string LTB_JSON_IN_VALUE;
 string LTB_JSON_OUT_TEXT;
 ldpl_list<string> LTB_JSON_OUT_TEXTLIST;
+void SETERRORCODE();
+ldpl_number LTB_EC;
+string LTB_ET;
+
 
 // Check if the request was successful from its response,
 // returning its 'result' field if OK, throwing error if not oK
@@ -31,7 +36,13 @@ void LTB_JSON_GETRESULT() {
     bool ok = j["ok"];
     if (!ok) {
         cerr << "LTB TG error #" << j["error_code"] << ": " << j["description"] << endl;
-        exit(1);
+        LTB_EC = 1;
+        LTB_ET = j["description"];
+        SETERRORCODE();
+    }else{
+        LTB_EC = 0;
+        LTB_ET = "";
+        SETERRORCODE();
     }
     LTB_JSON_OUT_TEXT = j["result"].dump();
 }

--- a/ltb.ldpl
+++ b/ltb.ldpl
@@ -26,6 +26,9 @@ ltb.json.in.value is external text
 ltb.json.out.text is external text
 ltb.json.out.textlist is external text list
 
+# error code and text
+ltb.ec is number
+ltb.et is text
 PROCEDURE:
 
 # Initializes the bot given its token and process the updates
@@ -204,4 +207,9 @@ procedure:
 
         call ltb.onDeparture with messageId chatId userData
     end if
+end sub
+
+external sub seterrorcode
+    store ltb.ec in ERRORCODE
+    store ltb.et in ERRORTEXT
 end sub


### PR DESCRIPTION
This fixes #1 by making LTB modify the ERRORCODE and ERRORTEXT variables and printing a warning on screen instead of crashing the whole program.